### PR TITLE
gitignoreでフォルダの指定方法の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 #自動生成されるやつは全部gitから消す
-*node_modules/
-*dist/
+node_modules/
+dist/


### PR DESCRIPTION
細かい話ですが、gitignoreでフォルダを指定する時は 
`*node_modules/` ではなく
`node_modules/` と記述するだけで十分です。

https://qiita.com/inabe49/items/16ee3d9d1ce68daa9fff#%E3%83%91%E3%82%BF%E3%83%BC%E3%83%B3